### PR TITLE
Don't use dotenv to load a .env file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,6 @@
 'use strict'
 
 
-require('dotenv').load()
-
-
 module.exports = Object.assign(
   {},
   require('./lib/convert'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,11 +102,6 @@
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   },
   "dependencies": {
     "@sydneyunilibrary/sierra-record-check-digit": "github:SydneyUniLibrary/sierra-record-check-digit#v1.1",
-    "big-integer": "^1.6.25",
-    "dotenv": "^4.0.0"
+    "big-integer": "^1.6.25"
   },
   "devDependencies": {
     "chai": "*",


### PR DESCRIPTION
It is up to the library users to use dotenv themselves, or set up the environment in whatever way they want.